### PR TITLE
update gemspec to latest specification

### DIFF
--- a/prawn-fast-png.gemspec
+++ b/prawn-fast-png.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   END
   s.add_dependency("prawn")
   s.add_dependency("rmagick")
-  s.has_rdoc = true
   s.extra_rdoc_files = %w{README.rdoc LICENSE COPYING}
   s.rdoc_options << "--title" << "prawn-fast-png documentation" <<
                     "--main"  << "README.rdoc" << "-q"


### PR DESCRIPTION
Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2011-10-01.
