### PR TITLE
require rmagick without deprecation messages

### DIFF
--- a/lib/prawn/images/png_patch.rb
+++ b/lib/prawn/images/png_patch.rb
@@ -5,7 +5,7 @@ unless Object.const_defined?(:Prawn)
   raise %q{Prawn not loaded yet. Make sure you "require 'prawn'" or "require 'prawn/core'" before "require 'prawn/fast_png'"}
 end
 
-require 'RMagick'
+require 'rmagick'
 
 module Prawn
   module Images


### PR DESCRIPTION
since 2.14, this commit of theirs:
https://github.com/gemhome/rmagick/commit/77827346b046c6e42ce27909970036d7cc1f16de
