### PR TITLE
Require rmagick first instead of deprecated RMagick

### DIFF
--- a/lib/prawn/images/png_patch.rb
+++ b/lib/prawn/images/png_patch.rb
@@ -5,7 +5,11 @@ unless Object.const_defined?(:Prawn)
   raise %q{Prawn not loaded yet. Make sure you "require 'prawn'" or "require 'prawn/core'" before "require 'prawn/fast_png'"}
 end
 
-require 'RMagick'
+begin
+  require 'rmagick'
+rescue LoadError
+  require 'RMagick'
+end
 
 module Prawn
   module Images


### PR DESCRIPTION
The deprecation message:
`[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead`