### PR TITLE
Require "rmagick" instead of "RMagick"

### DIFF
--- a/lib/prawn/images/png_patch.rb
+++ b/lib/prawn/images/png_patch.rb
@@ -5,7 +5,7 @@ unless Object.const_defined?(:Prawn)
   raise %q{Prawn not loaded yet. Make sure you "require 'prawn'" or "require 'prawn/core'" before "require 'prawn/fast_png'"}
 end
 
-require 'RMagick'
+require 'rmagick'
 
 module Prawn
   module Images


### PR DESCRIPTION
'RMagick' has been renamed to 'rmagick_internal', we should now require 'rmagick' (lowercase).

https://github.com/rmagick/rmagick/commit/e2c4b4310cb53ae7f8ad72a29957220d63169a3c